### PR TITLE
Upgrade werkzeug to 0.9.6: 'unicode' does not have the buffer interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Jinja2==2.7.2
 MarkupSafe==0.19
 Pygments==1.6
 SQLAlchemy==0.9.4
-Werkzeug==0.9.4
+Werkzeug==0.9.6
 coverage==3.7.1
 httpie==0.8.0
 itsdangerous==0.24


### PR DESCRIPTION
On Python 2.7.7+, unit tests are broken because of mitsuhiko/werkzeug#537.
